### PR TITLE
Use rmdir() rather than unlink() for removing nested directories

### DIFF
--- a/src/VirtualFilesystemAdapter.php
+++ b/src/VirtualFilesystemAdapter.php
@@ -133,6 +133,12 @@ class VirtualFilesystemAdapter extends Local {
      */
     protected function deleteFileInfoObject(SplFileInfo $file)
     {
+        if ($file->getType() === 'dir') {
+            rmdir($file->getPathname());
+
+            return;
+        }
+
         unlink($file->getPathname());
     }
 }

--- a/tests/Adapter/FileTests.php
+++ b/tests/Adapter/FileTests.php
@@ -245,4 +245,13 @@ class FileTests extends TestCase
         $file->delete();
         $this->assertFalse($this->filesystem->has('file.txt'));
     }
+
+    /** @test */
+    public function ensure_we_can_delete_a_nested_directory()
+    {
+        $this->filesystem->createDir('files/dir/nested');
+
+        $this->assertTrue($this->filesystem->deleteDir('files/dir'));
+        $this->assertFalse($this->filesystem->has('files/dir'));
+    }
 }


### PR DESCRIPTION
Currently I'm getting errors when deleting a directory containing one or more directories. 

The cause of this is calling `unlink()` on a directory in [`VirtualFilesystemAdapter::deleteFileInfoObject()`](https://github.com/stechstudio/laravel-vfs-adapter/blob/b4c8894c7a14de0ab3a1dcab70c4d92e7d747880/src/VirtualFilesystemAdapter.php#L136). See the where VFS wrapper throws an error [here](https://github.com/bovigo/vfsStream/blob/master/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php#L753).

These method calls are caused by the Flysystem local adapter cycling through the directory contents and [calling the `deleteFileInfoObject()` method with each item](https://github.com/thephpleague/flysystem/blob/master/src/Adapter/Local.php#L412) (including directories). 

The Flysystem adapter deals separately with deleting directories in its implementation of the affected method: [`League\Flysystem\Adapter\Local::deleteFileInfoObject()`](https://github.com/thephpleague/flysystem/blob/master/src/Adapter/Local.php#L421), so I've done the same in this PR which I think solves the issue.



