### PR TITLE
Change PHP versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
 
 sudo: false
 


### PR DESCRIPTION
Should fix the Travis build (that I broke a while ago..!) – Laravel 6 and its dependencies require PHP >=7.2 to be installed.

Older versions are now out of active support, and 7.1 loses security support in 1 month.